### PR TITLE
Fix the frequency of AC temperature update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-lg-thinq",
-  "version": "1.8.1",
+  "version": "1.8.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-lg-thinq",
-      "version": "1.8.1",
+      "version": "1.8.4",
       "funding": [
         {
           "type": "paypal",

--- a/src/devices/AirConditioner.ts
+++ b/src/devices/AirConditioner.ts
@@ -146,12 +146,14 @@ export default class AirConditioner extends baseDevice {
     // send request every minute to update temperature
     // https://github.com/nVuln/homebridge-lg-thinq/issues/177
     setInterval(() => {
-      this.platform.ThinQ?.deviceControl(device.id, {
-        dataKey: 'airState.mon.timeout',
-        dataValue: '70',
-      }, 'Set', 'allEventEnable', 'control').then(() => {
-        // success
-      });
+      if (device.online) {
+        this.platform.ThinQ?.deviceControl(device.id, {
+          dataKey: 'airState.mon.timeout',
+          dataValue: '70',
+        }, 'Set', 'allEventEnable', 'control').then(() => {
+          // success
+        });
+      }
     }, 60000);
   }
 

--- a/src/devices/AirConditioner.ts
+++ b/src/devices/AirConditioner.ts
@@ -149,7 +149,7 @@ export default class AirConditioner extends baseDevice {
       this.platform.ThinQ?.deviceControl(device.id, {
         dataKey: 'airState.mon.timeout',
         dataValue: '70',
-      }, 'Set', 'allEventEnable').then(() => {
+      }, 'Set', 'allEventEnable', 'control').then(() => {
         // success
       });
     }, 60000);

--- a/src/devices/AirConditioner.ts
+++ b/src/devices/AirConditioner.ts
@@ -663,7 +663,7 @@ export default class AirConditioner extends baseDevice {
         type: ValueType.Range,
         min: 0,
         max: 0,
-        step: 1,
+        step: 0.01,
       };
 
       if (minRange && maxRange) {

--- a/src/devices/AirConditioner.ts
+++ b/src/devices/AirConditioner.ts
@@ -663,7 +663,7 @@ export default class AirConditioner extends baseDevice {
         type: ValueType.Range,
         min: 0,
         max: 0,
-        step: 0.01,
+        step: 1,
       };
 
       if (minRange && maxRange) {
@@ -693,6 +693,7 @@ export default class AirConditioner extends baseDevice {
     const targetHeatTemperature = targetTemperature(tempHeatMinRange, tempHeatMaxRange);
 
     if (targetHeatTemperature) {
+      console.debug('targetHeatTemperature: ' + targetHeatTemperature.step);
       this.service.getCharacteristic(Characteristic.HeatingThresholdTemperature)
         .setProps({
           minValue: this.Status.convertTemperatureCelsiusFromLGToHomekit(targetHeatTemperature.min),
@@ -707,6 +708,7 @@ export default class AirConditioner extends baseDevice {
     const targetCoolTemperature = targetTemperature(tempCoolMinRange, tempCoolMaxRange);
 
     if (targetCoolTemperature) {
+      console.debug('targetCoolTemperature: ' + targetCoolTemperature.step);
       this.service.getCharacteristic(Characteristic.CoolingThresholdTemperature)
         .setProps({
           minValue: this.Status.convertTemperatureCelsiusFromLGToHomekit(targetCoolTemperature.min),

--- a/src/devices/AirConditioner.ts
+++ b/src/devices/AirConditioner.ts
@@ -693,7 +693,6 @@ export default class AirConditioner extends baseDevice {
     const targetHeatTemperature = targetTemperature(tempHeatMinRange, tempHeatMaxRange);
 
     if (targetHeatTemperature) {
-      console.debug('targetHeatTemperature: ' + targetHeatTemperature.step);
       this.service.getCharacteristic(Characteristic.HeatingThresholdTemperature)
         .setProps({
           minValue: this.Status.convertTemperatureCelsiusFromLGToHomekit(targetHeatTemperature.min),
@@ -708,7 +707,6 @@ export default class AirConditioner extends baseDevice {
     const targetCoolTemperature = targetTemperature(tempCoolMinRange, tempCoolMaxRange);
 
     if (targetCoolTemperature) {
-      console.debug('targetCoolTemperature: ' + targetCoolTemperature.step);
       this.service.getCharacteristic(Characteristic.CoolingThresholdTemperature)
         .setProps({
           minValue: this.Status.convertTemperatureCelsiusFromLGToHomekit(targetCoolTemperature.min),

--- a/src/lib/API.ts
+++ b/src/lib/API.ts
@@ -180,8 +180,8 @@ export class API {
     return this._homes;
   }
 
-  public async sendCommandToDevice(device_id: string, values: Record<string, any>, command: 'Set' | 'Operation', ctrlKey = 'basicCtrl') {
-    return await this.postRequest('service/devices/' + device_id + '/control-sync', {
+  public async sendCommandToDevice(device_id: string, values: Record<string, any>, command: 'Set' | 'Operation', ctrlKey = 'basicCtrl', ctrlPath = 'control-sync') {
+    return await this.postRequest('service/devices/' + device_id + '/' + ctrlPath, {
       ctrlKey,
       'command': command,
       ...values,

--- a/src/lib/ThinQ.ts
+++ b/src/lib/ThinQ.ts
@@ -171,9 +171,9 @@ export class ThinQ {
     });
   }
 
-  public deviceControl(device: string | Device, values: Record<string, any>, command: 'Set' | 'Operation' = 'Set', ctrlKey = 'basicCtrl') {
+  public deviceControl(device: string | Device, values: Record<string, any>, command: 'Set' | 'Operation' = 'Set', ctrlKey = 'basicCtrl', ctrlPath = 'control-sync') {
     const id = device instanceof Device ? device.id : device;
-    return this.api.sendCommandToDevice(id, values, command, ctrlKey)
+    return this.api.sendCommandToDevice(id, values, command, ctrlKey, ctrlPath)
       .then(response => {
         if (response.resultCode === '0000') {
           this.log.debug('ThinQ Device Received the Command');


### PR DESCRIPTION
This PR fixes an issue with the temperature update where it takes a lot of time to update sometime up to hours or days without opening the LG app. 
The correct endpoint to send MQTT commands to the device is /control not /control-sync as implemented on [this fix](https://github.com/ollo69/ha-smartthinq-sensors/commit/43a49835b8c2c4144fe06a0baeaeff8d38eca907).

The fix implements the following as well:
- Prevent sending monitoring control requests to offline devices to avoid errors. (A following PR will mark offline ACs with 'No Response')
- Set the default temperature control steps to 1.

Please review and let me know if things could be implemented in a better way and I would be happy to update as needed.