### PR TITLE
Fix AC rotation speed range

### DIFF
--- a/src/devices/AirConditioner.spec.ts
+++ b/src/devices/AirConditioner.spec.ts
@@ -106,7 +106,7 @@ describe('readAirConditionerState', () => {
     expect(status.currentTemperature).toBe(0);
     expect(status.targetTemperature).toBe(0);
     expect(status.airQuality).toBeNull();
-    expect(status.windStrength).toBe(5);
+    expect(status.windStrength).toBe(50);
     expect(status.isWindStrengthAuto).toBe(false);
     expect(status.isSwingOn).toBe(false);
     expect(status.isLightOn).toBe(false);
@@ -118,7 +118,7 @@ describe('readAirConditionerState', () => {
       'airState.windStrength': FAN_SPEED_AUTO,
     }, createDevice(), baseConfig, logger);
 
-    expect(status.windStrength).toBe(5);
+    expect(status.windStrength).toBe(50);
     expect(status.isWindStrengthAuto).toBe(true);
   });
 
@@ -239,8 +239,8 @@ describe('AirConditioner command mapping', () => {
     expect(temperatureRangePropsFromRange(null, temperature => temperature)).toBeNull();
     expect(fanRotationSpeedProps()).toEqual({
       minValue: 0,
-      maxValue: 5,
-      minStep: 0.1,
+      maxValue: 100,
+      minStep: 1,
     });
   });
 
@@ -354,7 +354,11 @@ describe('AirConditioner command mapping', () => {
 
   test('maps HomeKit rotation speed to LG wind strength', () => {
     expect(windStrengthFromRotationSpeed(1)).toBe(2);
-    expect(windStrengthFromRotationSpeed(3)).toBe(4);
+    expect(windStrengthFromRotationSpeed(25)).toBe(3);
+    expect(windStrengthFromRotationSpeed(50)).toBe(4);
+    expect(windStrengthFromRotationSpeed(75)).toBe(5);
+    expect(windStrengthFromRotationSpeed(100)).toBe(6);
+    expect(windStrengthFromRotationSpeed(125)).toBe(6);
     expect(windStrengthFromRotationSpeed(0)).toBe(2);
     expect(windStrengthFromRotationSpeed('not-a-number')).toBeNull();
   });
@@ -457,10 +461,7 @@ describe('AirConditioner command mapping', () => {
   });
 
   test('builds temperature keepalive commands only for online devices', () => {
-    expect(temperatureKeepAliveCommandForDevice({
-      id: 'ac-id',
-      online: true,
-    } as Device)).toEqual({
+    const expectedCommand = {
       deviceId: 'ac-id',
       payload: {
         dataKey: 'airState.mon.timeout',
@@ -469,7 +470,16 @@ describe('AirConditioner command mapping', () => {
       command: 'Set',
       ctrlKey: 'allEventEnable',
       ctrlPath: 'control',
-    });
+    };
+
+    expect(temperatureKeepAliveCommandForDevice({
+      id: 'ac-id',
+      online: true,
+    } as Device)).toEqual(expectedCommand);
+
+    expect(temperatureKeepAliveCommandForDevice({
+      id: 'ac-id',
+    } as Device)).toEqual(expectedCommand);
 
     expect(temperatureKeepAliveCommandForDevice({
       id: 'ac-id',

--- a/src/devices/AirConditioner.ts
+++ b/src/devices/AirConditioner.ts
@@ -14,6 +14,7 @@ export enum ACModelType {
 
 export const FAN_SPEED_AUTO = 8;
 export const AIR_CONDITIONER_TEMPERATURE_KEEP_ALIVE_INTERVAL_MS = 60000;
+export const AIR_CONDITIONER_TEMPERATURE_KEEP_ALIVE_MAX_FAILURES = 3;
 
 export enum FanSpeed {
   LOW = 2,
@@ -23,7 +24,7 @@ export enum FanSpeed {
   HIGH = 6
 }
 
-const HOMEKIT_FAN_SPEED_AUTO = 50;
+const HOMEKIT_FAN_SPEED_DEFAULT = 50;
 const HOMEKIT_FAN_SPEED_MAX = 100;
 const LG_FAN_SPEED_MIN = FanSpeed.LOW;
 const LG_FAN_SPEED_MAX = FanSpeed.HIGH;
@@ -255,13 +256,13 @@ function readWindStrength(data: any): number {
   const num = Number(raw);
   if (!isNaN(num)) {
     if (num === FAN_SPEED_AUTO) {
-      return HOMEKIT_FAN_SPEED_AUTO;
+      return HOMEKIT_FAN_SPEED_DEFAULT;
     }
     if (num >= LG_FAN_SPEED_MIN && num <= LG_FAN_SPEED_MAX) {
       return Math.round(((num - LG_FAN_SPEED_MIN) / (LG_FAN_SPEED_MAX - LG_FAN_SPEED_MIN)) * HOMEKIT_FAN_SPEED_MAX) || 1;
     }
   }
-  return HOMEKIT_FAN_SPEED_AUTO;
+  return HOMEKIT_FAN_SPEED_DEFAULT;
 }
 
 export function readAirConditionerState(data: any, device: Device, config: Config, logger: Logger): AirConditionerState {
@@ -685,6 +686,7 @@ export default class AirConditioner extends BaseDevice {
   protected currentTargetState = 2; // default target: COOL
 
   private temperatureKeepAliveInterval: ReturnType<typeof setInterval> | undefined;
+  private temperatureKeepAliveFailureCount = 0;
 
   protected serviceLabelButtons: Service | undefined;
 
@@ -759,13 +761,13 @@ export default class AirConditioner extends BaseDevice {
         keepAliveCommand.ctrlKey,
         keepAliveCommand.ctrlPath,
       ).then(success => {
-        if (!success) {
-          this.logger.debug(`[${device.name}] AC temperature keep-alive command was rejected; disabling keep-alive for this device.`);
-          this.stopTemperatureKeepAlive();
+        if (success) {
+          this.temperatureKeepAliveFailureCount = 0;
+          return;
         }
+        this.handleTemperatureKeepAliveFailure(device);
       }).catch(error => {
-        this.logger.debug(`[${device.name}] AC temperature keep-alive command failed; disabling keep-alive for this device.`, error);
-        this.stopTemperatureKeepAlive();
+        this.handleTemperatureKeepAliveFailure(device, error);
       });
     }, AIR_CONDITIONER_TEMPERATURE_KEEP_ALIVE_INTERVAL_MS);
 
@@ -779,6 +781,25 @@ export default class AirConditioner extends BaseDevice {
       clearInterval(this.temperatureKeepAliveInterval);
       this.temperatureKeepAliveInterval = undefined;
     }
+  }
+
+  private handleTemperatureKeepAliveFailure(device: Device, error?: unknown) {
+    this.temperatureKeepAliveFailureCount += 1;
+    if (this.temperatureKeepAliveFailureCount >= AIR_CONDITIONER_TEMPERATURE_KEEP_ALIVE_MAX_FAILURES) {
+      const message = `[${device.name}] AC temperature keep-alive command failed `
+        + `${this.temperatureKeepAliveFailureCount} consecutive times; disabling keep-alive for this device.`;
+      this.logger.debug(
+        message,
+        error,
+      );
+      this.stopTemperatureKeepAlive();
+      return;
+    }
+
+    this.logger.debug(
+      `[${device.name}] AC temperature keep-alive command failed; will retry.`,
+      error,
+    );
   }
 
   private setupTemperatureSensorService(accessory: PlatformAccessory<AccessoryContext>) {

--- a/src/devices/AirConditioner.ts
+++ b/src/devices/AirConditioner.ts
@@ -1,4 +1,4 @@
-import { AccessoryContext, BaseDevice } from '../baseDevice.js';
+import { AccessoryContext, BaseDevice, isDeviceOnlineForHomeKit } from '../baseDevice.js';
 import { LGThinQHomebridgePlatform } from '../platform.js';
 import { CharacteristicValue, Logger, PlatformAccessory, Service } from 'homebridge';
 import { Device } from '../lib/Device.js';
@@ -22,6 +22,11 @@ export enum FanSpeed {
   MEDIUM_HIGH = 5,
   HIGH = 6
 }
+
+const HOMEKIT_FAN_SPEED_AUTO = 50;
+const HOMEKIT_FAN_SPEED_MAX = 100;
+const LG_FAN_SPEED_MIN = FanSpeed.LOW;
+const LG_FAN_SPEED_MAX = FanSpeed.HIGH;
 
 enum OpMode {
   AUTO = 6,
@@ -250,15 +255,13 @@ function readWindStrength(data: any): number {
   const num = Number(raw);
   if (!isNaN(num)) {
     if (num === FAN_SPEED_AUTO) {
-      return Math.round(Object.keys(FanSpeed).length / 2);
+      return HOMEKIT_FAN_SPEED_AUTO;
     }
-    const min = 2;
-    const max = 6;
-    if (num >= min && num <= max) {
-      return Math.round(((num - min) / (max - min)) * 100) || 1;
+    if (num >= LG_FAN_SPEED_MIN && num <= LG_FAN_SPEED_MAX) {
+      return Math.round(((num - LG_FAN_SPEED_MIN) / (LG_FAN_SPEED_MAX - LG_FAN_SPEED_MIN)) * HOMEKIT_FAN_SPEED_MAX) || 1;
     }
   }
-  return Math.round(Object.keys(FanSpeed).length / 2);
+  return HOMEKIT_FAN_SPEED_AUTO;
 }
 
 export function readAirConditionerState(data: any, device: Device, config: Config, logger: Logger): AirConditionerState {
@@ -366,8 +369,8 @@ export function temperatureRangePropsFromRange(
 export function fanRotationSpeedProps(): AirConditionerFanRotationSpeedProps {
   return {
     minValue: 0,
-    maxValue: Object.keys(FanSpeed).length / 2,
-    minStep: 0.1,
+    maxValue: HOMEKIT_FAN_SPEED_MAX,
+    minStep: 1,
   };
 }
 
@@ -532,8 +535,8 @@ export function windStrengthFromRotationSpeed(value: CharacteristicValue): numbe
     return null;
   }
 
-  const speedValue = Math.max(1, Math.round(vNum));
-  return parseInt(Object.keys(FanSpeed)[speedValue - 1]) || FanSpeed.HIGH;
+  const speedPercent = Math.max(0, Math.min(HOMEKIT_FAN_SPEED_MAX, vNum));
+  return Math.round(LG_FAN_SPEED_MIN + (speedPercent / HOMEKIT_FAN_SPEED_MAX) * (LG_FAN_SPEED_MAX - LG_FAN_SPEED_MIN));
 }
 
 export function swingCommandsForMode(value: CharacteristicValue, swingMode: string): AirConditionerSwingCommand[] {
@@ -640,7 +643,7 @@ export function coolModeFeatureCommandFromState(
 export function temperatureKeepAliveCommandForDevice(
   device: Pick<Device, 'id' | 'online'>,
 ): AirConditionerKeepAliveCommand | null {
-  if (!device.online) {
+  if (!isDeviceOnlineForHomeKit(device)) {
     return null;
   }
 
@@ -755,8 +758,14 @@ export default class AirConditioner extends BaseDevice {
         keepAliveCommand.command,
         keepAliveCommand.ctrlKey,
         keepAliveCommand.ctrlPath,
-      ).then(() => {
-        // success
+      ).then(success => {
+        if (!success) {
+          this.logger.debug(`[${device.name}] AC temperature keep-alive command was rejected; disabling keep-alive for this device.`);
+          this.stopTemperatureKeepAlive();
+        }
+      }).catch(error => {
+        this.logger.debug(`[${device.name}] AC temperature keep-alive command failed; disabling keep-alive for this device.`, error);
+        this.stopTemperatureKeepAlive();
       });
     }, AIR_CONDITIONER_TEMPERATURE_KEEP_ALIVE_INTERVAL_MS);
 


### PR DESCRIPTION
﻿## Summary
- expose AC fan `RotationSpeed` as HomeKit's normal 0-100 percentage range instead of 0-5
- map HomeKit fan percentages back to LG wind strength values when setting AC fan speed
- retry AC temperature keep-alive failures and disable the keep-alive loop only after repeated consecutive failures

## Root Cause
Issue #373 reports AC devices sending `RotationSpeed` value `100` while the service declared a maximum of `5`. The AC state parser already converted LG wind strength values into percentages, but the HomeKit characteristic props still used the number of LG fan levels as the maximum.

The same logs also show repeated LG `0101` responses for the AC temperature keep-alive command. That command is useful for devices that accept it, but unsupported devices should stop retrying after repeated failures while transient failures continue to retry.

Closes #373.

## Validation
- `npm run lint`
- `npm test -- src/devices/AirConditioner.spec.ts --runInBand`