### PR TITLE
Fix Dehumidifier power on/off via Apple Home

### DIFF
--- a/src/devices/Dehumidifier.ts
+++ b/src/devices/Dehumidifier.ts
@@ -3,6 +3,7 @@ import { LGThinQHomebridgePlatform } from '../platform.js';
 import { CharacteristicValue, Logger, PlatformAccessory } from 'homebridge';
 import { Device } from '../lib/Device.js';
 import { snapshotBoolean, snapshotNumber, updateCharacteristicIfChanged } from './helpers.js';
+import { normalizeBoolean } from '../utils/normalize.js';
 
 enum RotateSpeed {
   LOW = 2,
@@ -129,19 +130,26 @@ export default class Dehumidifier extends BaseDevice {
 
   async setActive(value: CharacteristicValue) {
     this.requireDeviceOnline();
-    this.platform.log.debug('Set Dehumidifier Active State ->', value);
     const device: Device = this.accessory.context.device;
-    const isOn = value as boolean;
-    if (this.Status.isPowerOn && isOn) {
+    const isOn = normalizeBoolean(value);
+    const isOnNumeric = isOn ? 1 : 0;
+    this.platform.log.debug('Set Dehumidifier Active State ->', isOnNumeric, ' current status = ', this.Status.isPowerOn);
+    if ((this.Status.isPowerOn && isOnNumeric === 1) || (!this.Status.isPowerOn && isOnNumeric === 0)) {
       return; // don't send same status
     }
 
-    await this.platform.ThinQ?.deviceControl(device.id, {
-      dataKey: 'airState.operation',
-      dataValue: isOn,
-    });
-    device.data.snapshot['airState.operation'] = isOn ? 1 : 0;
-    this.updateAccessoryCharacteristic(device);
+    try {
+      const success = await this.platform.ThinQ?.deviceControl(device.id, {
+        dataKey: 'airState.operation',
+        dataValue: isOnNumeric,
+      }, 'Operation');
+      if (success) {
+        device.data.snapshot['airState.operation'] = isOnNumeric;
+        this.updateAccessoryCharacteristic(device);
+      }
+    } catch (error) {
+      this.logger.error('Error setting active state:', error);
+    }
   }
 
   async setHumidityThreshold(value: CharacteristicValue) {


### PR DESCRIPTION
## Summary

Apple Home's Active toggle for `Dehumidifier` accessories had no effect on the physical device: HomeKit immediately bounced back to the previous state. The cause is that `setActive()` in `src/devices/Dehumidifier.ts` sends `airState.operation` with the default `'Set'` command type, but the LG ThinQ device model spec requires `'Operation'` for that key.

Looking at the firmware-provided `ControlDevice` spec for a Korean DHUM_056905 unit:

```json
{
  "ctrlKey": "basicCtrl",
  "comment": "원격제어-기본제어, 운전모드, 바람세기, 희망습도",
  "command": "Operation|Get|Set",
  "dataKey": "airState.operation|airState.opMode|airState.windStrength|airState.humidity.desired",
  "dataValue": "{%airState.operation%}|{%airState.opMode%}|{%airState.windStrength%}|{%airState.humidity.desired%}"
}
```

The pipe-aligned mapping says `airState.operation → Operation`. The LG cloud silently accepts `'Set'` (returns `resultCode: 0000`) but ignores the command, which is why no error surfaces in the Homebridge log.

The `AirConditioner.setActive()` implementation already does this correctly (`src/devices/AirConditioner.ts:1640-1643`). This PR aligns `Dehumidifier.setActive()` with the same pattern.

## Changes

In `Dehumidifier.setActive()`:

- Pass `'Operation'` as the third argument to `deviceControl()`.
- Normalize the incoming `CharacteristicValue` via `normalizeBoolean()` and send a numeric `1/0`, matching `AirConditioner.setActive()`. The previous code sent the raw HomeKit value typed as `boolean`, which is actually a number (`Characteristic.Active.ACTIVE = 1` / `INACTIVE = 0`).
- Guard against both already-on→on and already-off→off (the previous guard only suppressed the redundant on→on case).
- Wrap in `try/catch` and only update the local snapshot when `deviceControl()` returns `true`, so the UI does not desync if the command fails.

## Verification

Verified on a DHUM_056905 (Korean market dehumidifier) running plugin `2.0.0-beta.6`:

- Before patch: Apple Home toggle bounces back, no error in `homebridge.log`, device stays off.
- After patch: Apple Home toggle starts/stops the dehumidifier reliably.

Type-check (`npx tsc --noEmit`) and lint (`npx eslint src/devices/Dehumidifier.ts`) pass.

## Test plan

- [ ] Toggle a `DEHUMIDIFIER` accessory in Apple Home → device powers on
- [ ] Toggle off → device powers off
- [ ] Rapid double-toggle does not get suppressed unexpectedly
- [ ] No regression on other LG ThinQ devices